### PR TITLE
Unable to create test report becase TESTOMATIO has special chars

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           REPORT: 'test-results/report.json'
           PROC: 'auto'
-          TESTOMATIO: ${{ secrets.TESTOMATIO_API_KEY }}
+          TESTOMATIO: '${{ secrets.TESTOMATIO_API_KEY }}'
           TESTOMATIO_CODE_STYLE: 'pep8'
 
       - name: Generate Pretty Report


### PR DESCRIPTION
Getting error mesage from github action because run_details is None Object. After checking source code, it unable to create test run because errors. Adding single quote to avoid break errors. 
```
2024-08-24T15:40:22.9793630Z INTERNALERROR>   File "/opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/pytestomatio/main.py", line 54, in pytest_configure
2024-08-24T15:40:22.9794644Z INTERNALERROR>     run_id = run_details.get('uid')
2024-08-24T15:40:22.9795145Z INTERNALERROR>              ^^^^^^^^^^^^^^^
2024-08-24T15:40:22.9795744Z INTERNALERROR> AttributeError: 'NoneType' object has no attribute 'get'
```